### PR TITLE
Added ability to work on ritual encounter

### DIFF
--- a/InventoryItemsAnalyzer.cs
+++ b/InventoryItemsAnalyzer.cs
@@ -132,18 +132,25 @@ namespace InventoryItemsAnalyzer
                 var normalInventoryItems = _ingameState.IngameUi.InventoryPanel[InventoryIndex.PlayerInventory]
                     .VisibleInventoryItems;
 
-                var ritualItems = _ingameState.IngameUi.RitualWindow.Items;
+                try
+                {
+                    var ritualItems = _ingameState.IngameUi.RitualWindow.Items;
 
-                var allItems = normalInventoryItems.Concat(ritualItems).ToList();
+                    normalInventoryItems = normalInventoryItems.Concat(ritualItems).ToList();
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
 
-                var temp = allItems.Count(t => t.Item?.GetComponent<Mods>()?.Identified == true);
+                var temp = normalInventoryItems.Count(t => t.Item?.GetComponent<Mods>()?.Identified == true);
 
                 //LogMessage(normalInventoryItems.Count.ToString() + " " + CountInventory.ToString() + " // " + temp .ToString() + " " + idenf.ToString(), 3f);
 
-                if (allItems.Count != _countInventory || temp != _idenf)
+                if (normalInventoryItems.Count != _countInventory || temp != _idenf)
                 {
-                    ScanInventory(allItems);
-                    _countInventory = allItems.Count;
+                    ScanInventory(normalInventoryItems);
+                    _countInventory = normalInventoryItems.Count;
                     _idenf = temp;
                 }
 

--- a/InventoryItemsAnalyzer.cs
+++ b/InventoryItemsAnalyzer.cs
@@ -132,14 +132,18 @@ namespace InventoryItemsAnalyzer
                 var normalInventoryItems = _ingameState.IngameUi.InventoryPanel[InventoryIndex.PlayerInventory]
                     .VisibleInventoryItems;
 
-                var temp = normalInventoryItems.Count(t => t.Item?.GetComponent<Mods>()?.Identified == true);
+                var ritualItems = _ingameState.IngameUi.RitualWindow.Items;
+
+                var allItems = normalInventoryItems.Concat(ritualItems).ToList();
+
+                var temp = allItems.Count(t => t.Item?.GetComponent<Mods>()?.Identified == true);
 
                 //LogMessage(normalInventoryItems.Count.ToString() + " " + CountInventory.ToString() + " // " + temp .ToString() + " " + idenf.ToString(), 3f);
 
-                if (normalInventoryItems.Count != _countInventory || temp != _idenf)
+                if (allItems.Count != _countInventory || temp != _idenf)
                 {
-                    ScanInventory(normalInventoryItems);
-                    _countInventory = normalInventoryItems.Count;
+                    ScanInventory(allItems);
+                    _countInventory = allItems.Count;
                     _idenf = temp;
                 }
 
@@ -845,7 +849,7 @@ namespace InventoryItemsAnalyzer
                     {
                         chaosValue = Convert.ToSingle((string) line?["chaosValue"], formatter);
 
-                        if (chaosValue < Settings.ChaosProphecy.Value)
+                        if (chaosValue < Settings.ChaosDivCard.Value)
                             result.Add((string) line?["name"]);
                     }
                 }


### PR DESCRIPTION
I created a new class for Ritual in Queuete's HUD, so this should work also on ritual encounters. I tried changing as little code as possible, so it's kinda a dirty way to implement this. It's all in the try catch block, so the plugin still works if you don't use the Queuete's version.
Also fixed a bug in code. Divcards were priced based on prophecy settings. 